### PR TITLE
updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,15 @@ sudo apt-get update
 sudo apt-get -y install cuda-toolkit-12-6
 ```
 
-After installing the CUDA Toolkit in WSL2, you need to add the CUDA binaries to your system's PATH and the libraries to your LD_LIBRARY_PATH. Here's how to do that for CUDA 12.6:
+After installing the CUDA Toolkit 12.6 in WSL2, you need to configure your system to recognize and use it. This involves creating a symbolic link to set CUDA 12.6 as the default version and updating your environment variables so your shell can locate the CUDA tools and libraries.
 
+By exporting the PATH and LD_LIBRARY_PATH variables in your ~/.bashrc, you ensure that these settings are applied automatically every time you open a terminal, making CUDA 12.6 available in all future sessions without needing to reconfigure it manually.
+
+Here’s how to do that:
 ```
-export PATH=/usr/local/cuda-12.6/bin:$PATH
-export LD_LIBRARY_PATH=/usr/local/cuda-12.6/lib64:$LD_LIBRARY_PATH
+sudo ln -sfn /usr/local/cuda-12.6 /usr/local/cuda
+echo -e '\nexport PATH=/usr/local/cuda/bin:$PATH' >> ~/.bashrc
+echo 'export LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH' >> ~/.bashrc
 source ~/.bashrc
 ```
 
@@ -114,6 +118,15 @@ Now confirm that CUDA Toolkit is installed:
 ```
 nvcc --version
 ```
+or 
+```
+/usr/local/cuda/bin/nvcc --version
+```
+You should see output like:
+```
+V12.6.0
+```
+This confirms that CUDA Toolkit 12.6 is installed and available for use.
 
 ---
 


### PR DESCRIPTION
The previous method to set the path variables only worked on the current session they had been set on and would be lost in any newer sessions. 
In order to have `CUDA 12.6` set to path variables across all sessions (current or newer) i.e. as default unless set otherwise seems like the better way to do it. 
We could always change to other versions of `CUDA` as mentioned in the troubleshooting part. But having to configure the path for `CUDA` in every session seems like an unnecessary hassle.

This method here links the path of my mentioned CUDA version 12.6 in this case in the following way:
`sudo ln -sfn /usr/local/cuda-12.6 /usr/local/cuda`
and then saves the path variables in the `~/.bashrc` file so it prevails across all sessions (if not changed).

If we want to install a newer version and have it as default, we will only need to run:
`sudo ln -sfn /usr/local/cuda-{VERSION} /usr/local/cuda` and `source ~/.bashrc` which should do the trick.
So, if we wanted to have `CUDA 11.8` as our default from now on we would do:
`sudo ln -sfn /usr/local/cuda-11.8 /usr/local/cuda` and then `source ~/.bashrc`
